### PR TITLE
Added firmware and silo dependency for better installs

### DIFF
--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.exccmodules.control-center.ezuicache
 Name: EzUICache
-Version: 0.0.1
+Version: 0.0.2
 Architecture: iphoneos-arm
 Description: A UICache button for Control Center with Silo.
 Author: M4cs and Chilaxan

--- a/control
+++ b/control
@@ -6,3 +6,4 @@ Description: A UICache button for Control Center with Silo.
 Author: M4cs and Chilaxan
 Section: Control Center (Modules)
 Maintainer: m4cs.yourepo.com
+Depends: firmware (>= 11.0), com.ioscreatix.silo


### PR DESCRIPTION
This will ensure that people 

1. Are at least on Firmware 11.0 or higher as Silo and these modules are not made for lower anyway.

2. Have Silo installed or have Cydia queue it for installation and if they do not have the creatix repo added they'll be presented with an error and a block on installing the module